### PR TITLE
Check for `to_string` also for object serialization

### DIFF
--- a/src/xh_h2x.h
+++ b/src/xh_h2x.h
@@ -71,7 +71,10 @@ xh_h2x_resolve_value(xh_h2x_ctx_t *ctx, SV *value, xh_uint_t *type)
         *type = 0;
 
         if (SvOBJECT(value)) {
-            if ((method = gv_fetchmethod_autoload(SvSTASH(value), "toString", 0)) != NULL) {
+            if (
+                  ((method = gv_fetchmethod_autoload(SvSTASH(value), "toString",  0)) != NULL)
+               || ((method = gv_fetchmethod_autoload(SvSTASH(value), "to_string", 0)) != NULL) 
+            ){
                 dSP;
 
                 ENTER; SAVETMPS; PUSHMARK(SP);


### PR DESCRIPTION
Popular CPAN modules like `Mojolicious` provides `to_string` but not `toString`. Without this change  we either have to monkeypatch `Mojo::URL` to provide `toString`, or to manually flatten objects before passing to `hash2xml`.

I haven't tested the change, just opening pull request to see if it's something you would be interested in accepting. I do not know performance impact of change like this, but perhaps it would be nice to also add another popular variation - `as_string`. 

But perhaps ideally, if there is way to detect that class has an `overload` for  `q{""}`, that should be used instead - is it possible to detect via XS?

Thanks